### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 MediumLightbox
 =============
 
-####Nice and elegant way to add zooming functionality for images, inspired by medium.com
+#### Nice and elegant way to add zooming functionality for images, inspired by medium.com
 
 This plugin reproduce exactly the same code that use Medium to add the smooth transition effect clicking over the images, with some improvement.
 * **It works on mobile**, unlike [Medium](https:/medium.com).
 * **It's simple**, unlike [Fluidbox](http://terrymun.github.io/Fluidbox/).
 
-#####Key features
+##### Key features
 Written in pure javascript for better performance, lightweight and simple. [View demo](http://davidecalignano.it/project/files/medium-lightbox/demo/demo.html).
-#####Use
+##### Use
 
 **Include**
 
@@ -35,7 +35,7 @@ The aspect ratio percentage is found with [(height/width)*100] formula.
 **Initialize plugin**
 
 	MediumLightbox('figure.zoom-effect');
-####Option
+#### Option
 
     MediumLightbox('figure.zoom-effect', {
         margin:40
@@ -43,5 +43,5 @@ The aspect ratio percentage is found with [(height/width)*100] formula.
 * **Margin** - default: 20 - Margin in px applied to the image in zoomed view.
 
 
-####Preview | [Live demo](http://davidecalignano.it/project/files/medium-lightbox/demo/demo.html)
+#### Preview | [Live demo](http://davidecalignano.it/project/files/medium-lightbox/demo/demo.html)
 ![alt text](http://davidecalignano.it/project/files/medium-lightbox/medium-lightbox-demo.gif "Demo")


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
