### PR TITLE
Fix chrome blurry image after zoom

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,6 +86,7 @@ figure.full{
 .zoom-effect .img{
 	cursor: pointer;
 	cursor: -webkit-zoom-in;
+	backface-visibility: hidden;
 }
 
 .zoom-effect .zoomImg,


### PR DESCRIPTION
I found bug in chrome. After img zoom image was blurred. 